### PR TITLE
feat: Handle if blocks with no else

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export function joinReplace(str: string, variables: Record<string, any>): string
 }
 
 export function ifElseReplace(str: string, variables: Record<string, any>): string {
-  const regex = /{{\s*if\s*(.+?)\s*}}([\S\s]*?){{\s*else\s*}}([\S\s]*?){{\s*end\s*}}/;
+  const regex = /{{\s*if\s*(.+?)\s*}}([\S\s]*?)({{\s*else\s*}}([\S\s]*?))?{{\s*end\s*}}/;
   let result = str;
   let m: RegExpMatchArray | null;
 
@@ -51,7 +51,7 @@ export function ifElseReplace(str: string, variables: Record<string, any>): stri
     const all = m[0];
     const condition = m[1];
     const onTrue = m[2];
-    const onFalse = m[3];
+    const onFalse = m[4] || '';
 
     if (condition.startsWith('.')) {
       let conditionResultState = false;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -37,7 +37,7 @@ describe('ifElse', () => {
     );
   });
   it('should allow true with no else block', () => {
-    const keywords = '';
+    const keywords = 'swag';
     expect(ifElseReplace('{{ if .keywords }}hello{{end}}', { keywords })).toBe(
       'hello',
     );

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -36,6 +36,18 @@ describe('ifElse', () => {
       'nothing',
     );
   });
+  it('should allow true with no else block', () => {
+    const keywords = '';
+    expect(ifElseReplace('{{ if .keywords }}hello{{end}}', { keywords })).toBe(
+      'hello',
+    );
+  });
+  it('should allow false with no else block', () => {
+    const keywords = '';
+    expect(ifElseReplace('{{ if .keywords }}hello{{end}}', { keywords })).toBe(
+      '',
+    );
+  });
 });
 
 describe('range', () => {


### PR DESCRIPTION
Just a quick update to handle `{{ if .whatever }}stuff{{ end }}`. Includes unit tests so should be fairly robust.